### PR TITLE
Try specialized combinations iterator

### DIFF
--- a/src/CausalInference.jl
+++ b/src/CausalInference.jl
@@ -7,5 +7,6 @@ export dsep, skeleton, gausscitest, dseporacle, partialcor
 
 include("skeleton.jl")
 include("dsep.jl")
+include("combinations_without.jl")
 
 end # module

--- a/src/combinations_without.jl
+++ b/src/combinations_without.jl
@@ -1,0 +1,85 @@
+# Combinations iterator with tabu 
+using Combinatorics
+import Base: start, next, eltype, done, length
+
+immutable CombinationsWithout{T}
+    a::T
+    t::Int
+    w::Int
+    l::Int
+    L::Int
+end
+
+function start(c::CombinationsWithout) 
+    s = zeros(Int, c.t)
+    if 0 < c.t <= c.l 
+        s[1] = 1
+        if c.w == 1
+            s[1] = 2
+        end
+        i = 1
+        while i < c.t
+            i += 1
+            s[i] = s[i-1] + 1
+            if s[i] == c.w
+                s[i] += 1
+            end
+        end
+    end
+    s, Vector{eltype(c.a)}(c.t), 1
+end    
+
+function next(c::CombinationsWithout, state)
+    s, comb, k =  state
+    k += 1
+    for i in 1:c.t
+        
+        comb[i] = c.a[s[i]]
+    end
+    for i = length(s):-1:1
+        s[i] += 1
+        if s[i] > c.l - (length(s)-i) -  (s[i] <= c.w) 
+            continue
+        end
+        if s[i] == c.w
+            s[i] += 1
+        end
+        for j = i+1:endof(s)
+            s[j] = s[j-1]+1
+            if s[j] == c.w
+                s[j] += 1
+            end
+        end
+        break
+    end
+    comb, (s, comb, k)
+end
+done(c::CombinationsWithout, state) = state[3] > c.L
+    
+length(c::CombinationsWithout) = c.L
+eltype{T}(::Type{CombinationsWithout{T}}) = Vector{eltype(T)}
+
+"""
+    combinations_without(a, t::Integer, w)
+
+Generate all combinations of `n` elements from an indexable object except those with index `w`. Note that the combinations 
+are modified inplace.
+"""
+function combinations_without(a, t::Integer, w)
+    #println(a, " ", t, " ", w)
+    l = length(a)
+    ins = 1 <= w <= l
+    L = binomial(l - ins, t)
+    if ins && length(a) == w # w is last index
+        CombinationsWithout(a, t, 0, l - 1, L)
+    elseif ins && l == t # t too big
+        CombinationsWithout(a, t, w, l, 0)
+    elseif ins 
+        CombinationsWithout(a, t, w, l, L)
+    else
+        CombinationsWithout(a, t, 0, l, L)
+    end
+end
+
+
+

--- a/src/dsep.jl
+++ b/src/dsep.jl
@@ -18,7 +18,7 @@ function dsep(g::AbstractGraph, u::Integer, v::Integer, S; verbose = false)
         blocked[ve] = true
     end
    
-    (in_seen[u] || in_seen[v]) && throw(ArgumentError("S should not contain u or v"))
+    (in_seen[u] || in_seen[v]) && throw(ArgumentError("S=$S should not contain u=$u or v=$v"))
     
     u == v && throw(ArgumentError("u == v"))
     

--- a/src/skeleton.jl
+++ b/src/skeleton.jl
@@ -29,12 +29,14 @@ function skeleton(n::V, I, par...) where {V}
         isdone = true
         for e0 in collect(edges(g)) # cannot remove edges while iterating
             for e in (e0, reverse(e0))
-                nb0 = neighbors(g, src(e))
-                if length(nb0) > d  # i.e. |nb\{dst(e)}| >= d 
-                    nb = copy(nb0)
-                    removesorted!(nb, dst(e))
+                nb = neighbors(g, src(e))
+                if length(nb) > d  # i.e. |nb\{dst(e)}| >= d 
+                    r = searchsorted(nb, dst(e))
+                    if isempty(r) 
+                        continue
+                    end
                     isdone = false
-                    for s in combinations(nb, d)
+                    for s in combinations_without(nb, d,  first(r)) # do not modify s!
                         if I(src(e), dst(e), s, par...) 
                             rem_edge!(g, e0)
                             if !(e0 in keys(S))


### PR DESCRIPTION
In skeleton, we need to iterate over combinations from a set with one vertex missing.
Currently we create a costly copy.
One can iterate over all combinations of a subset without specifically creating a subset. The iterator is difficult to reason about, so I did this on a branch:

This branch:
```
julia> include("test/perf.jl")
  3.103890 seconds (24.02 M allocations: 1.051 GiB, 38.02% gc time)
inferred edges 874
```
Switched to branch 'master'
```
julia> include("test/perf.jl")
 10.131600 seconds (51.08 M allocations: 12.424 GiB, 44.99% gc time)
inferred edges 874
```