### PR TITLE
fixed LightGraphs deprecation warning

### DIFF
--- a/src/skeleton.jl
+++ b/src/skeleton.jl
@@ -23,7 +23,7 @@ Perform the undirected PC skeleton algorithm for a set of 1:n variables using th
 Returns skeleton graph and separating set  
 """
 function skeleton(n::V, I, par...; kwargs...) where {V}
-    g = CompleteGraph(n)
+    g = complete_graph(n)
     S = Dict{edgetype(g),Vector{V}}()
     d = 0 # depth
     

--- a/test/skeleton.jl
+++ b/test/skeleton.jl
@@ -7,7 +7,7 @@ using LinearAlgebra
 using Statistics
 
 function skeleton2(n::V, I, par...) where {V}
-    g = CompleteGraph(n)
+    g = complete_graph(n)
     S = Dict{edgetype(g),Vector{V}}()
     d = 0 # depth
     while true


### PR DESCRIPTION
While running unit tests for the project, a deprecation warning showed up from the `LightGraphs` module. This PR fixes this warning.