### PR TITLE
WIP: Algorithm for counting the number of consistent extensions (size of an MEC given a CPDAG)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Memoization = "6fafb56a-5788-4b4e-91ca-c0cea6611c73"
+LinkedLists = "70f5e60a-1556-5f34-a19e-a48b3e4aaee9"
 MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
@@ -21,6 +22,15 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 TabularDisplay = "3eeacb1d-13c2-54cc-9b18-30c86af3cadb"
 ThreadsX = "ac1d9e8a-700a-412c-b207-f0111f4b6c0d"
+
+[weakdeps]
+GraphRecipes = "bd48cda9-67a9-57be-86fa-5b3c104eda73"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+TikzGraphs = "b4f28e30-c73f-5eaf-a395-8a9db949a742"
+
+[extensions]
+GraphRecipesExt = ["GraphRecipes", "Plots"]
+TikzGraphsExt = "TikzGraphs"
 
 [compat]
 Combinatorics = "1.0"
@@ -42,10 +52,6 @@ TabularDisplay = "1.2"
 ThreadsX = "0.1"
 TikzGraphs = "1.3, 1.4"
 julia = "1.6, 1.7, 1.8, 1.9"
-
-[extensions]
-GraphRecipesExt = ["GraphRecipes", "Plots"]
-TikzGraphsExt = "TikzGraphs"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/src/CausalInference.jl
+++ b/src/CausalInference.jl
@@ -13,7 +13,7 @@ import Base: ==, show
 export ancestors, descendants, alt_test_dsep, test_covariate_adjustment, alt_test_backdoor, find_dsep, find_min_dsep, find_covariate_adjustment, find_backdoor_adjustment, find_frontdoor_adjustment, find_min_covariate_adjustment, find_min_backdoor_adjustment, find_min_frontdoor_adjustment, list_dseps, list_covariate_adjustment, list_backdoor_adjustment, list_frontdoor_adjustment
 export dsep, skeleton, gausscitest, dseporacle, partialcor
 export unshielded, pcalg, vskel, vskel!, alt_vskel
-export cpdag, alt_cpdag, meek_rules!
+export cpdag, alt_cpdag, meek_rules!, MECsize
 export digraph, vpairs, skel_oracle, pc_oracle, randdag
 export cmitest, kl_entropy, kl_renyi, kl_mutual_information
 export kl_cond_mi, kl_perm_mi_test, kl_perm_cond_mi_test

--- a/src/CausalInference.jl
+++ b/src/CausalInference.jl
@@ -4,6 +4,7 @@ using Graphs
 using Graphs.SimpleGraphs
 using Combinatorics
 using Base.Iterators
+using LinkedLists
 using Memoization, LRUCache
 using ThreadsX
 
@@ -44,6 +45,7 @@ include("backdoor.jl")
 include("ges.jl")
 include("gensearch.jl")
 include("workloads.jl")
+include("chordal.jl")
 
 # Compatibility with the new "Package Extensions" (https://github.com/JuliaLang/julia/pull/47695)
 const EXTENSIONS_SUPPORTED = isdefined(Base, :get_extension)

--- a/src/chordal.jl
+++ b/src/chordal.jl
@@ -1,0 +1,165 @@
+import LinkedLists
+
+"""
+    ischordal(g)
+
+Return true if the given graph is chordal
+"""
+function ischordal(G)
+    mcsorder, invmcsorder, _ = mcs(G, Set())
+    
+    n = length(mcsorder)
+    
+    f = zeros(Int, n)
+    index = zeros(Int, n)
+    for i=n:-1:1
+        w = mcsorder[i]
+        f[w] = w
+        index[w] = i
+        for v in neighbors(G, w)
+            if invmcsorder[v] > i
+                index[v] = i
+                if f[v] == v
+                    f[v] = w
+                end
+            end
+        end
+        for v in neighbors(G, w)
+            if invmcsorder[v] > i
+                if index[f[v]] > i
+                    return false
+                end
+            end
+        end
+    end
+    return true
+end
+
+function cliquetreefrommcs(G, mcsorder, invmcsorder)
+    n = nv(G)
+    # data structures for the algorithm
+    K = Vector{Set}()
+    push!(K, Set())
+    s = 1
+    edgelist = Set{Edge}()
+    visited = falses(n)
+    clique = zeros(Int, n)
+
+    for i = 1:n
+        x = mcsorder[i]
+        S = Set{Int}()
+        for w in inneighbors(G, x)
+            if visited[w]
+                push!(S, w)
+            end
+        end
+        
+        # if necessary create new maximal clique
+        if K[s] != S
+            s += 1
+            push!(K, S)
+            k, _ = findmax(map(x -> invmcsorder[x], collect(S)))
+            p = clique[mcsorder[k]]
+            push!(edgelist, Edge(p, s))
+        end
+        
+        union!(K[s], x)
+        clique[x] = s 
+        visited[x] = true;
+    end
+
+    T = SimpleGraphFromIterator(edgelist)
+    # ensure graph is not empty
+    nv(T) == 0 && add_vertices!(T,1)
+    return K, T
+end
+
+@inline function vispush!(l::LinkedList, pointers, x, vis)
+    if vis
+        pointers[x] = push!(l,x)
+    else
+        pointers[x] = pushfirst!(l,x)
+    end
+end
+
+# TODO: separate mcs and mcs plus cgk??
+# Returns the visit order of the vertices, its inverse and the subgraphs C_G(K) (see Def. 1 in [1,2]). If K is empty a normal MCS is performed.
+function mcs(G, K)
+    n = nv(G)
+    copy_K = copy(K)
+    
+    # data structures for MCS
+    sets = [LinkedList{Int}() for _ = 1:n+1]
+    pointers = Vector(undef,n)
+    size = Vector{Int}(undef, n)
+    visited = falses(n)
+    
+    # output data structures
+    mcsorder = Vector{Int}(undef, n)
+    invmcsorder = Vector{Int}(undef, n)
+    subgraphs = Array[]
+
+    # init
+    visited[collect(copy_K)] .= true
+    for v in vertices(G)
+        size[v] = 1
+        vispush!(sets[1], pointers, v, visited[v])
+    end
+    maxcard = 1
+
+    for i = 1:n
+        # first, the vertices in K are chosen
+        # they are always in the set of maximum cardinality vertices
+        if !isempty(copy_K)
+            v = pop!(copy_K)
+        # afterwards, the algorithm chooses any vertex from maxcard
+        else
+            v = first(sets[maxcard])
+        end
+        # v is the ith vertex in the mcsorder
+        mcsorder[i] = v
+        invmcsorder[v] = i
+        size[v] = -1
+
+        # immediately append possible subproblems to the output
+        if !visited[v]
+            vertexset = Vector{Int}()
+            for x in sets[maxcard]
+                visited[x] && break
+                visited[x] = true
+                push!(vertexset, x)
+            end
+            sg = induced_subgraph(G, vertexset)
+            subgraphs = vcat(subgraphs, (map(x -> sg[2][x], connected_components(sg[1]))))
+        end
+
+        deleteat!(sets[maxcard], pointers[v])
+
+        # update the neighbors
+        for w in inneighbors(G, v)
+            if size[w] >= 1
+                deleteat!(sets[size[w]], pointers[w])
+                size[w] += 1
+                vispush!(sets[size[w]], pointers, w, visited[w])
+            end
+        end
+        maxcard += 1
+        while maxcard >= 1 && isempty(sets[maxcard])
+            maxcard -= 1
+        end
+    end
+
+    return mcsorder, invmcsorder, subgraphs
+end
+
+"""
+    cliquetree(G)
+
+Computes a clique tree of a graph G. A vector K of maximal cliques and a tree T on 1,2,...,|K| is returned.
+
+"""
+function cliquetree(G)
+    mcsorder, invmcsorder, _ = mcs(G, Set())
+    K, T = cliquetreefrommcs(G, mcsorder, invmcsorder)
+    return K, T
+end

--- a/src/cpdag.jl
+++ b/src/cpdag.jl
@@ -1,6 +1,6 @@
 import Base: iterate, length
 
-# replace by struct TODO
+# replace by struct?
 function fac(n, fmemo)
     fmemo[n] != 0 && return fmemo[n]
     n == 1 && return BigInt(1)

--- a/src/cpdag.jl
+++ b/src/cpdag.jl
@@ -81,6 +81,59 @@ function alt_cpdag(g)
     return nvertexdigraphfromedgelist(nv(g), edgelist)
 end
 
+# TODOs:
+# - add function for checking whether a graph is a CDPAG
+# - add function for checking whether a PDAG has a DAG extension
+function hasdirectedcycle(G)
+    # TODO: implement
+    return true
+end
+
+function ismaximallyoriented(G)
+    # TODO: implement
+    return true
+end
+
+function checkundirectedcomps(G)
+    # TODO: implement
+    return true, true
+end
+
+function isstronglyprotected(G)
+    # TODO: implement
+    return true
+end
+
+"""
+    classifygraph(G)
+Classifies a graph efficiently into the following classes:
+- "cyclic": has a directed cycle (the graph can also satisfy some of the other criteria)
+- "not maximally oriented": there is an undirected edge whose direction would follow from one of the Meek rules (Meek 1995)
+- "not extendable": there is no consistent DAG extension of this graph
+- "CPDAG": the graph is a CPDAG
+- "MPDAG, counting works" and "MPDAG, counting not yet implemented": in both cases the graph is an MPDAG, however, in the second case it has not enough structure for the counting algorithm to work (TODO: add more details)
+"""
+
+function classifygraph(G)
+    hasdirectedcycle(G) && return "cyclic"
+    ismaximallyoriented(G) && return "not maximally oriented"
+    areinduced, arechordal = checkundirectedcomps(G)
+    !arechordal && return "not extendable"
+    if areinduced
+        if isstronglyprotected(G)
+            return "CPDAG"
+        else
+            return "MPDAG, counting works"
+        end
+    else
+        return "MPDAG, counting not yet implemented"
+    end
+end
+
+function consistent_extension(G)
+    # TODO: implement Dor-Tarsi algorithm
+end
+
 
 """
     ordered_edges(dag)


### PR DESCRIPTION
Next step I think is adding the following methods, most of which are already implemented, but I'm still thinking about the proper way to integrate them (and need some time to polish them):
- Given a CPDAG, *count* the number of DAGs in the Markov equivalence class (i.e., consistent extensions of the CPDAG) https://arxiv.org/abs/2012.09679 and also https://arxiv.org/abs/2205.02654
- Given a PDAG, *count* the number of its consistent extensions (this one I haven't implemented yet, but methods from the bullet point above can be generalized with the caveat that it's not polynomial time anymore)
- Given a PDAG or CPDAG, *list* all consistent extensions: https://arxiv.org/abs/2301.12212
- There is some other minor stuff closely adjacent to this, but gonna focus on the three above first...

First some explanation, what is the difference between PDAGs and CPDAGs (how I use the terms) and why it is relevant:
A CPDAG represents a Markov equivalence class (MEC) and has the same skeleton and v-structures as the DAGs in the MEC plus additional orient edges that follow from the v-structures by the Meek rules. Hence, for MEC {a -> b -> c, a <- b <- c, a <- b -> c} the CPDAG would be a - b - c.

In contrast a <- b - c is not a CPDAG (even if it is fully oriented by the Meek rules) because it does not represent (via the def. of consistent extensions) a full Markov equivalence class, but only the two DAGs {a <- b -> c and a <- b <- c} which form a subclass of the one above. (Such graphs (which are completed under the Meek rules but non necessarily CPDAGs) are also called MPDAGs.)

The first method for counting the number of consistent extensions only works for CPDAGs (and some generalizations), but not for PDAGs or MPDAGs in general. In particular, applying it to a graph which is not a CPDAG could simply give the wrong result (e.g., there are x consistent extensions but the algorithm will spit out the number y). The reason for this is that CPDAGs have a number of nice properties that the algorithm relies on (e.g. that a - b - c implies that there cannot be a -> c, which we use in GES; this holds neither for PDAGs nor for MPDAGs).

This is all fine for the GES algorithm, which is guaranteed to output a CPDAG, but the PC algorithm might not. The PC algorithm could (when mistakes happen during independence testing) output graphs which are not CPDAGs. Actually, this happens extremely often (from my experience) and the graph obtained by learning the skeleton and the v-structures moreover often has no consistent extension (i.e., Dor-Tarsi would output an error for such an input in the current implementation). It has to be said that applying the Meek rules to a PDAG, which has no consistent extension, might make the graph "extendable" again: E.g. after skeleton and v-structure phase one might have (due to errors in independence testing) a -> b <- c and g -> f <- h and b - d - e - f. Then, applying the Meek rules will fully orient the chain b - d - e - f (in which way depends on the implementation and vertex numbering). The graph is then a DAG and thus trivially has itself as consistent extension (what happened here is that the Meek rules introduced a new v-structure; this can happen if the given PDAG is not extendable). 

The most unopinionated way of including the methods is to just give proper warning about the output of the PC algorithm. One could also include a check into the functions that expect a CPDAG, i.e., they first test whether the graph is a CPDAG/fulfills the necessary conditions for the algorithm to output the correct result (but that would of course make the methods slower).

Generally, I think that something along those lines would be fine (and in any case, I'm probably going to polish the algorithms itself for a while before we have to settle for a solution to this), but I wanted to draw attention to this problem. 

There are a lot of practical methods, which are build on top of observational causal discovery, which to a higher or lesser degree demand the output graph to be a CPDAG and it's not great that the sample PC algorithm does not provide one. I guess the reason why people still often prefer standard PC is that every orientation in the output graph comes (more or less) directly from conditional independencies which via the Markov property have a rather clear causal interpretation (though even here applying the Meek rules might introduce (arbitrary) new v-structures in case of errors). If one were to e.g. try to augment the output of PC to be a CPDAG, the causal interpretation is certainly less clear.