### PR TITLE
Add exact score based algorithm for causal structure learning

### DIFF
--- a/docs/src/examples/ges_basic_examples.md
+++ b/docs/src/examples/ges_basic_examples.md
@@ -85,3 +85,18 @@ posterior = sort(keyedreduce(+, graph_pairs, ws); byvalue=true, rev=true)
 ```
 
 From this we see that the maximum a posterior graph coincides with the GES estimate and has high posterior weight, showing that the result of the GES algorithm is not incidental.  
+
+## Exact Algorithm
+
+We also provide an implementation of the exact optimization algorithm by Silander and Myllymäki (2006). Given observed data, it outputs the CPDAG representing the set of DAGs with maximum BIC score. The algorithm is exact, meaning it is guaranteed that the optimal CPDAG with regard to the BIC score is found.
+
+The time and memory complexity of the algorithm is in the order of $O(n \cdot 2^{n-1})$ with $n$ being the number of variables (which is significantly better than a naive brute-force algorithm, which considers all CPDAGs on $n$ vertices, but still amounts to exponential time). The algorithm generally runs reasonably fast for less than 20 variables. It can be scaled further, provided enough RAM is available, up to a little more than 25 variables, but cases beyond that are likely infeasible.
+
+It can be called similar to GES:
+```Julia
+est_g = exactscorebased(df; penalty=1.0, parallel=true)
+```
+
+Reference:
+
+* Silander, T., & Myllymäki, P. (2006). A simple approach for finding the globally optimal Bayesian network structure. In Uncertainty in Artificial Intelligence (pp. 445-452). 

--- a/src/CausalInference.jl
+++ b/src/CausalInference.jl
@@ -12,6 +12,7 @@ using LinkedLists
 
 import Base: ==, show
 
+export exactscorebased
 export ancestors, descendants, alt_test_dsep, test_covariate_adjustment, alt_test_backdoor, find_dsep, find_min_dsep, find_covariate_adjustment, find_backdoor_adjustment, find_frontdoor_adjustment, find_min_covariate_adjustment, find_min_backdoor_adjustment, find_min_frontdoor_adjustment, list_dseps, list_covariate_adjustment, list_backdoor_adjustment, list_frontdoor_adjustment
 export dsep, skeleton, gausscitest, dseporacle, partialcor
 export unshielded, pcalg, vskel, vskel!, alt_vskel
@@ -27,7 +28,7 @@ export plot_pc_graph_text, plot_fci_graph_text, kwargs_pdag_graphmakie
 export plot_pc_graph_recipes, plot_fci_graph_recipes # if GraphRecipes is loaded
 export plot_pc_graph_tikz, plot_fci_graph_tikz # if TikzGraphs is loaded
 export orient_unshielded, orientable_unshielded, apply_pc_rules
-export ges
+export ges, local_score
 export pdag2dag!, pdag_to_dag_meek!, pdag_to_dag_dortasi!
 export count_moves_uniform, randcpdag, UniformScore, causalzigzag
 export keyedreduce
@@ -52,6 +53,7 @@ include("workloads.jl")
 include("operators.jl")
 include("sampler.jl")
 include("misc2.jl")
+include("exact.jl")
 #include("mcs.jl")
 
 # Compatibility with the new "Package Extensions" (https://github.com/JuliaLang/julia/pull/47695)

--- a/src/exact.jl
+++ b/src/exact.jl
@@ -1,0 +1,150 @@
+using Graphs
+
+include("misc.jl")
+include("cpdag.jl")
+
+@inline subset_range(n) = 0:2^n-1
+@inline subset_size(n) = 2^n
+@inline element_range(n) = 0:n-1
+
+get_subset(j, n) = [k+1 for k = element_range(n) if ((1 << k) & j) != 0]
+# for vertex i and subset j find the indexed parent set
+get_parents(i, j, n) = [k+1 for k = element_range(n) if (k < i && 1 << k & j != 0) || (k > i && 1 << (k-1) & j != 0)]
+
+function compute_bestparents(i, n, localscores) 
+    bestscores = zeros(subset_size(n-1))
+    bestparents = zeros(Int64, subset_size(n-1))
+    for j = subset_range(n-1)
+        bestscores[j+1] = localscores[i+1][j+1]
+        bestparents[j+1] = j
+        for k = element_range(n-1)
+            subj = j & ~(1 << k)
+            subj == j && continue
+            if bestscores[subj+1] > bestscores[j+1]
+                bestscores[j+1] = bestscores[subj+1]
+                bestparents[j+1] = bestparents[subj+1]
+            end
+        end
+    end
+    return bestparents
+end
+
+function compute_bestsinks(n, bestparents, localscores)
+    bestscores = zeros(subset_size(n))
+    bestsinks = -1 * ones(Int64, subset_size(n))
+    for j = subset_range(n)
+        for k = element_range(n)
+            1 << k & j == 0 && continue
+            subj = j & ~(1 << k)
+            before = (subj & (1 << k - 1))
+            after = subj - before
+            psubj = before + (after >> 1)
+            subscore = bestscores[subj+1] + localscores[k+1][bestparents[k+1][psubj+1]+1]
+            if bestsinks[j+1] == -1 || subscore > bestscores[j+1]
+                bestscores[j+1] = subscore 
+                bestsinks[j+1] = k
+            end
+        end
+    end
+    return bestsinks
+end 
+
+function compute_ordering(n, bestsinks)
+    ordering = zeros(Int64, n)
+    remaining = subset_size(n) - 1
+    for i = reverse(element_range(n))
+        ordering[i+1] = bestsinks[remaining+1]
+        remaining = remaining - 1 << ordering[i+1]
+    end
+    return ordering
+end
+
+function compute_network(n, ordering, bestparents)
+    g = SimpleDiGraph(n)
+    predecs = 0
+    for i in element_range(n)
+        before = (predecs & (1 << ordering[i+1] - 1))
+        after = predecs - before
+        idx = before + (after >> 1)
+        parents = get_parents(ordering[i+1], bestparents[ordering[i+1]+1][idx+1], n)
+        for p in parents
+            add_edge!(g, p, ordering[i+1]+1)
+        end
+        predecs += 1 << ordering[i+1]
+    end
+    return g
+end
+
+# implements exact score based algorithm described in
+# https://arxiv.org/pdf/1206.6875.pdf
+# complexity is n*2^n, should scale up to ~20-25 variables (then memory becomes a problem)
+# can be parallelized
+
+# TODO: test non-oracle version
+#function exactscorebased(X::AbstractMatrix; method=:gaussian_bic, penalty=0.5, parallel=false, verbose=false)
+#    (_, n) = size(X)
+#    n > 30 && @warn "algorithm will take a long time to terminate and needs a lot of memory"
+#    n > 64 && @error "algorithm only works up to 64 variables (and will likely not be feasible for more than 30 variables)"
+#    
+#    if method == :gaussian_bic
+#        C = Symmetric(cov(X, dims = 1, corrected = false))
+#        return exactscorebased(n, GaussianScore(C, n, penalty); parallel, verbose)
+#    elseif method == :gaussian_bic_raw
+#        return exactscorebased(n, GaussianScoreQR(X, penalty); parallel, verbose)
+#    else 
+#        throw(ArgumentError("method=$method"))
+#    end
+#end
+
+function oracle_score(g, parents, v)
+    real_parents = inneighbors(g, v)
+    return -length(symdiff(parents, real_parents))
+end
+
+function exactscorebased(g::SimpleDiGraph; parallel=false, verbose=false)
+    n = nv(g)
+    local_score(parents, v) = oracle_score(g, parents, v)
+    exactscorebased(n, local_score; parallel, verbose)
+end
+
+function exactscorebased(n, local_score; parallel=false, verbose=false)
+    # Step 1: calculate score for all n*2^(n-1) different (variable, variable set) pairs (variable and parents)
+    localscores = [Vector{Float64}() for _ = 1:n]
+    # TODO: parallelize loop
+    for i = element_range(n)
+        localscores[i+1] = [local_score(get_parents(i, j, n), i+1) for j = subset_range(n-1)]
+    end
+
+    # Step 2: find the best parents for all vertices and subsets (of candidate parents)
+    bestparents = [Vector{Int64}() for _ = 1:n]
+    # TODO: parallelize loop
+    for i = element_range(n)
+        bestparents[i+1] = compute_bestparents(i, n, localscores)
+    end
+
+    # Step 3: find the best sink for all subsets of variables
+    bestsinks = compute_bestsinks(n, bestparents, localscores)
+
+    # Step 4: find best ordering of vertices
+    ordering = compute_ordering(n, bestsinks)
+    verbose && println("ordering" * string(ordering))
+
+    # Step 5: find best network
+    return alt_cpdag(compute_network(n, ordering, bestparents))
+end
+
+function testexact() 
+    Random.seed!(58)
+    for n in [6, 8, 10, 12, 14, 16, 18]
+        println(n)
+        for alpha in [0.2, 3/n]
+            g = randdag(n, alpha)
+            res = exactscorebased(g)
+            if alt_cpdag(g) != res 
+                println(g)
+                println(res)
+                return
+            end
+        end 
+    end
+end

--- a/src/exact.jl
+++ b/src/exact.jl
@@ -77,8 +77,10 @@ end
 """ 
     exactscorebased(X; method=:gaussian_bic, penalty=0.5, parallel=false, verbose=false)
 
-Compute a CPDAG for the given observed data `X` (variables in columns) using the exact algorithm proposed by Silander and Myllymäki in https://arxiv.org/pdf/1206.6875.pdf for optimizing the BIC score (or any decomposable score).  
+Compute a CPDAG for the given observed data `X` (variables in columns) using the exact algorithm proposed by Silander and Myllymäki (2006) for optimizing the BIC score (or any decomposable score).  
 The complexity is n*2^n and the algorithm should scale up to ~20-25 variables, afterwards memory becomes a problem.
+
+* Silander, T., & Myllymäki, P. (2006). A simple approach for finding the globally optimal Bayesian network structure. In Uncertainty in Artificial Intelligence (pp. 445-452). 
 """
 function exactscorebased(X::AbstractMatrix; method=:gaussian_bic, penalty=0.5, parallel=false, verbose=false)
     (_, n) = size(X)
@@ -96,6 +98,7 @@ function exactscorebased(X::AbstractMatrix; method=:gaussian_bic, penalty=0.5, p
         throw(ArgumentError("method=$method"))
     end
 end
+exactscorebased(X; method=:gaussian_bic, penalty=0.5, parallel=false, verbose=false) = exactscorebased(Tables.matrix(X); method, penalty, parallel, verbose)
 
 function exactscorebased(n, local_score; parallel=false, verbose=false)
     # Step 1: calculate score for all n*2^(n-1) different (variable, variable set) pairs (variable and parents)

--- a/test/exact.jl
+++ b/test/exact.jl
@@ -3,6 +3,7 @@ using Test, Random, Statistics, Combinatorics
 using LinearAlgebra, StatsBase
 using Memoization
 
+# doesn't work without this include (because I call exactscorebased(n, local_score) directly which I guess is not exported?)
 include("../src/exact.jl")
 
 function oracle_score(g, parents, v)
@@ -21,6 +22,17 @@ end
         for alpha in [0.2, 3/n]
             g = randdag(n, alpha)
             res = exactscorebased(g)
+            @test alt_cpdag(g) == res 
+        end 
+    end
+end
+
+@testset "exact oracle parallel" begin 
+    Random.seed!(58)
+    for n in [6, 8, 10, 12, 14, 16, 18]
+        for alpha in [0.2, 3/n]
+            g = randdag(n, alpha)
+            res = exactscorebased(g; parallel=true)
             @test alt_cpdag(g) == res 
         end 
     end

--- a/test/exact.jl
+++ b/test/exact.jl
@@ -1,0 +1,54 @@
+using Distributions, CausalInference, Graphs
+using Test, Random, Statistics, Combinatorics
+using LinearAlgebra, StatsBase
+using Memoization
+
+include("../src/exact.jl")
+
+function oracle_score(g, parents, v)
+    real_parents = inneighbors(g, v)
+    return -length(symdiff(parents, real_parents))
+end
+
+function exactscorebased(g::SimpleDiGraph; parallel=false, verbose=false)
+    n = nv(g)
+    exactscorebased(n, (parents, v) -> oracle_score(g, parents, v); parallel, verbose)
+end
+
+@testset "exact oracle" begin 
+    Random.seed!(58)
+    for n in [6, 8, 10, 12, 14, 16, 18]
+        println(n)
+        for alpha in [0.2, 3/n]
+            g = randdag(n, alpha)
+            res = exactscorebased(g)
+            @assert alt_cpdag(g) == res 
+        end 
+    end
+end
+
+@testset "exact data" begin
+    seed = 123
+    Random.seed!(seed)
+    K = 50
+    for k in 1:K
+        qu(x) = x * x'
+        d = 8
+        alpha = 2.5/d
+        n = 20000
+        penalty = 0.00005
+        g = randdag(d, alpha)
+        E = Matrix(adjacency_matrix(g)) # Markov operator multiplies from right 
+        L = E .* (0.3rand(d, d) .+ 0.3)
+        # Do not actually sample but compute true correlation
+        Σtrue = Float64.(inv(big.(qu((I - L)))))
+        di = sqrt.(diag(Σtrue))
+        Ctrue = (Σtrue) ./ (di * di')
+        S = GaussianScore(Ctrue, n, penalty)
+
+        @assert g == DiGraph(E)
+
+        cg = alt_cpdag(g)
+        @assert cg == exactscorebased(d, (p, v) -> local_score(S, p, v))
+    end
+end

--- a/test/exact.jl
+++ b/test/exact.jl
@@ -18,11 +18,10 @@ end
 @testset "exact oracle" begin 
     Random.seed!(58)
     for n in [6, 8, 10, 12, 14, 16, 18]
-        println(n)
         for alpha in [0.2, 3/n]
             g = randdag(n, alpha)
             res = exactscorebased(g)
-            @assert alt_cpdag(g) == res 
+            @test alt_cpdag(g) == res 
         end 
     end
 end
@@ -49,6 +48,6 @@ end
         @assert g == DiGraph(E)
 
         cg = alt_cpdag(g)
-        @assert cg == exactscorebased(d, (p, v) -> local_score(S, p, v))
+        @test cg == exactscorebased(d, (p, v) -> local_score(S, p, v))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using CausalInference
 using Graphs
 using Test
 
+include("exact.jl")
 include("operators.jl")
 include("ges.jl")
 include("gesvsR.jl")


### PR DESCRIPTION
Implemented an exact score based causal-structure/Bayesian-network learning algorithm. For any decomposable scoring function it computes the CPDAG with the optimal score. 

The implementation is based on https://arxiv.org/pdf/1206.6875.pdf. The main workload of the algorithm is to compute the local score for all variables and every possible parent set (amounting to $n*2^{n-1}$ many evaluations of the scoring function). The algorithm likely scales to 20-25 variables (then memory will become an issue; we could address this by storing some of the preprocessing to disk), but I haven't done thorough testing yet. This covers many practical settings. 

There are many other exact score based algorithms as well. As far as I'm aware, all of them need $n*2^{n-1}$ score evaluations in the general case, thus for our purposes implementing one algorithm should suffice (the algorithms have their pros/cons mostly when the maximum number of parents $k$ is set beforehand, reducing the number of score evaluations to $n * 2^{k}$, however I find this rather artificial; still we could add this easily). 

Currently I only used the algorithm for an oracle score, we need to integrate it with the BIC score from GES. 