### PR TITLE
fix typo dor tarsi

### DIFF
--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -31,7 +31,7 @@ CausalInference.meek_rule2
 CausalInference.meek_rule3
 CausalInference.meek_rule4
 pdag2dag!
-pdag_to_dag_dortasi!
+pdag_to_dag_dortarsi!
 pdag_to_dag_meek!
 ```
 

--- a/src/CausalInference.jl
+++ b/src/CausalInference.jl
@@ -29,7 +29,7 @@ export plot_pc_graph_recipes, plot_fci_graph_recipes # if GraphRecipes is loaded
 export plot_pc_graph_tikz, plot_fci_graph_tikz # if TikzGraphs is loaded
 export orient_unshielded, orientable_unshielded, apply_pc_rules
 export ges, local_score
-export pdag2dag!, pdag_to_dag_meek!, pdag_to_dag_dortasi!
+export pdag2dag!, pdag_to_dag_meek!, pdag_to_dag_dortarsi!
 export count_moves_uniform, randcpdag, UniformScore, causalzigzag
 export keyedreduce
 

--- a/src/pdag.jl
+++ b/src/pdag.jl
@@ -205,11 +205,11 @@ Returns sorted array.
 children(g, x) = setdiff(outneighbors(g, x), inneighbors(g, x))
 
 """
-    pdag_to_dag_dortasi!!(g)
+    pdag_to_dag_dortarsi!!(g)
 
-Complete PDAG to DAG using Dor & Tasi (1992).
+Complete PDAG to DAG using Dor & Tarsi (1992).
 """
-function pdag_to_dag_dortasi!(g)
+function pdag_to_dag_dortarsi!(g)
     removed = falses(nv(g)) # Mark vertices removed from (sub-)graph A. Efficient if degree small?
     while !all(removed)
         touched = false

--- a/src/pdag.jl
+++ b/src/pdag.jl
@@ -205,7 +205,7 @@ Returns sorted array.
 children(g, x) = setdiff(outneighbors(g, x), inneighbors(g, x))
 
 """
-    pdag_to_dag_dortarsi!!(g)
+    pdag_to_dag_dortarsi!(g)
 
 Complete PDAG to DAG using Dor & Tarsi (1992).
 """

--- a/test/cpdag.jl
+++ b/test/cpdag.jl
@@ -58,7 +58,7 @@ for stable in (true, false)
             h1 = pc_oracle(g; stable)
             h2 = cpdag(g)
            
-            g2 = pdag_to_dag_dortasi!(copy(h2))
+            g2 = pdag_to_dag_dortarsi!(copy(h2))
             @test !is_cyclic(g2)
             @test h2 == cpdag(g2)
      


### PR DESCRIPTION
There was a typo in the name of the second author of https://ftp.cs.ucla.edu/pub/stat_ser/r185-dor-tarsi.pdf.

All places where it occurs should be fixed

~~EDIT: is the library.md file automatically generated? else we need to fix it there as well~~