### PR TITLE
minor version bump (0.16.0 -> 0.17.0) causal equations  for Julia registration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CausalInference"
 uuid = "8e462317-f959-576b-b3c1-403f26cec956"
 authors = ["Moritz Schauer <moritzschauer@web.de>"]
-version = "0.16.0"
+version = "0.17.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"


### PR DESCRIPTION
Changing the version of CausalInference  package (0.16.0 -> 0.17.0)  to register new causal equations functionality.

 @JuliaRegistrator register

