### PR TITLE
Exact score based algorithm optimizations

### DIFF
--- a/src/exact.jl
+++ b/src/exact.jl
@@ -90,10 +90,10 @@ function exactscorebased(X::AbstractMatrix; method=:gaussian_bic, penalty=0.5, p
     if method == :gaussian_bic
         C = Symmetric(cov(X, dims = 1, corrected = false))
         S = GaussianScore(C, N, penalty)
-        return exactscorebased(n, (p, v) -> local_score(S, p, v) ; parallel, verbose)
+        return exactscorebased(n, (p, v) -> local_score_(S, p, v) ; parallel, verbose)
     elseif method == :gaussian_bic_raw
         S = GaussianScoreQR(X, penalty)
-        return exactscorebased(n, (p, v) -> local_score(S, p, v); parallel, verbose)
+        return exactscorebased(n, (p, v) -> local_score_(S, p, v); parallel, verbose)
     else 
         throw(ArgumentError("method=$method"))
     end

--- a/src/ges.jl
+++ b/src/ges.jl
@@ -359,8 +359,8 @@ function local_score_(os::GaussianScore, p, v)
         c = C[p_, v]
         Cp = C[v, v] - c*(C[p_, p_]\c)
     else # compute conditional correlation
-        c = @view C[p, v]
-        Cp = C[v, v] - dot(c, (@view C[p, p])\c)
+        c = C[p, v]
+        Cp = C[v, v] - dot(c, C[p, p]\c)
     end
     (-n*(1 + log(max(0,Cp))) - penalty*(1  + k)*log(n))/2
 end


### PR DESCRIPTION
Some fairly free optimizations. I benchmarked briefly for graphs with 16 vertices. 

- avoiding the unnecessary memoizations by calling ```local_score_``` directly: reduces execution time from ~2.5s to ~1.2s (so roughly 1s faster)
- removing ```@view``` which I think can hurt because the submatrix is not contiguous: reduces execution time from ~1.2s to ~1.1s 

We should definitely fix the first point (that was just an oversight that these calls are memoized)...

Second point we could benchmark GES on larger graphs first

UPDATE: the ```@view``` thing doesn't make a big difference for GES, so I have no big preference whether we keep it