### PR TITLE
Faster implementation of maximum cardinality search.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -38,7 +38,7 @@ GraphRecipesExt = ["GraphRecipes", "Plots"]
 TikzGraphsExt = "TikzGraphs"
 
 [compat]
-CliqueTrees = "0.2.1"
+CliqueTrees = "0.3"
 Combinatorics = "1.0"
 DelimitedFiles = "1.6, 1.7, 1.8, 1.9"
 Distances = "0.8, 0.9, 0.10"

--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,13 @@ authors = ["Moritz Schauer <moritzschauer@web.de>"]
 version = "0.18.0"
 
 [deps]
+CliqueTrees = "60701a23-6482-424a-84db-faee86b9b1f8"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-LinkedLists = "70f5e60a-1556-5f34-a19e-a48b3e4aaee9"
 LogarithmicNumbers = "aa2f6b4e-9042-5d33-9679-40d3a6b85899"
 Memoization = "6fafb56a-5788-4b4e-91ca-c0cea6611c73"
 MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
@@ -38,6 +38,7 @@ GraphRecipesExt = ["GraphRecipes", "Plots"]
 TikzGraphsExt = "TikzGraphs"
 
 [compat]
+CliqueTrees = "0.2.1"
 Combinatorics = "1.0"
 DelimitedFiles = "1.6, 1.7, 1.8, 1.9"
 Distances = "0.8, 0.9, 0.10"
@@ -47,7 +48,6 @@ GraphRecipes = "0.5"
 Graphs = "1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 1.12"
 LRUCache = "1.4, 1.5, 1.6"
 LinearAlgebra = "1"
-LinkedLists = "0.1"
 LogarithmicNumbers = "1.4"
 Memoization = "0.2"
 MetaGraphs = "0.7, 0.8"

--- a/src/CausalInference.jl
+++ b/src/CausalInference.jl
@@ -8,7 +8,6 @@ using Combinatorics
 using Base.Iterators
 using Memoization, LRUCache
 using ThreadsX
-using LinkedLists
 
 import Base: ==, show
 


### PR DESCRIPTION
I have a library [CliqueTrees.jl](https://github.com/AlgebraicJulia/CliqueTrees.jl/tree/main) with a faster implementation of the maximum cardinality algorithm. Here are some benchmarks.

```julia
julia> using BenchmarkTools, MatrixMarket, SuiteSparseMatrixCollection, Graphs

julia> using CausalInference: count_mcs

julia> ssmc = ssmc_db(); name = "venturiLevel3";

julia> graph = DiGraph(mmread(joinpath(fetch_ssmc(ssmc[ssmc.name .== name, :], format="MM")[1], "$(name).mtx")))
{4026819, 16108474} directed simple Int64 graph
```

**current version**

```julia
julia> @benchmark count_mcs($graph)
BenchmarkTools.Trial: 6 samples with 1 evaluation per sample.
 Range (min … max):  710.482 ms …    1.613 s  ┊ GC (min … max): 32.27% … 69.52%
 Time  (median):     765.882 ms               ┊ GC (median):    32.35%
 Time  (mean ± σ):   895.824 ms ± 353.408 ms  ┊ GC (mean ± σ):  44.48% ± 15.14%

  █ ▁ ▁ ▁                                                     ▁  
  █▁█▁█▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  710 ms           Histogram: frequency by time          1.61 s <

 Memory estimate: 706.63 MiB, allocs estimate: 20134711.
```

**new version**

```julia
julia> @benchmark count_mcs($graph)
BenchmarkTools.Trial: 18 samples with 1 evaluation per sample.
 Range (min … max):  274.436 ms … 311.835 ms  ┊ GC (min … max): 0.00% … 1.62%
 Time  (median):     288.422 ms               ┊ GC (median):    1.17%
 Time  (mean ± σ):   289.501 ms ±  11.964 ms  ┊ GC (mean ± σ):  1.09% ± 1.10%

  ▁▁ █  ▁ ▁ ▁      ▁▁        ▁  ▁ ▁     █    ▁     ▁ ▁        ▁  
  ██▁█▁▁█▁█▁█▁▁▁▁▁▁██▁▁▁▁▁▁▁▁█▁▁█▁█▁▁▁▁▁█▁▁▁▁█▁▁▁▁▁█▁█▁▁▁▁▁▁▁▁█ ▁
  274 ms           Histogram: frequency by time          312 ms <

 Memory estimate: 153.61 MiB, allocs estimate: 15.
```

You can take a look at the implementation [here](https://github.com/AlgebraicJulia/CliqueTrees.jl/blob/5cafd6f69c7a2e6b489b06d9797c31285741e7eb/src/elimination_algorithms.jl#L391).